### PR TITLE
fix inverted price-check logic and remove dead code in Constants

### DIFF
--- a/Source/FindAGunDamnIt/Constants.cs
+++ b/Source/FindAGunDamnIt/Constants.cs
@@ -19,14 +19,5 @@ public static class Constants
     static Constants()
     {
         SimpleSidearmsLoaded = ModLister.HasActiveModWithName("Simple sidearms");
-        if (FindAGunDamnItMod.Instance.Settings != null)
-        {
-            return;
-        }
-
-        if (FindAGunDamnItMod.Instance.Settings != null)
-        {
-            FindAGunDamnItMod.Instance.Settings.FindingSetting = FindAGunDamnItMod.FindingSettings[0];
-        }
     }
 }

--- a/Source/FindAGunDamnIt/Gunfitter.cs
+++ b/Source/FindAGunDamnIt/Gunfitter.cs
@@ -176,7 +176,7 @@ public static class Gunfitter
             }
         }
 
-        if (FindAGunDamnItMod.Instance.Settings.IgnorePrice && newGun.MarketValue <= oldGun.MarketValue)
+        if (!FindAGunDamnItMod.Instance.Settings.IgnorePrice && newGun.MarketValue <= oldGun.MarketValue)
         {
             LogMessage($"{newGun} is worth less than {oldGun}, ignoring.");
             return false;


### PR DESCRIPTION
- `Gunfitter.compareGuns`: the `IgnorePrice` condition was backwards — pawns were rejecting cheaper weapons *when told to ignore price* and ignoring price *when told to consider it*. Flipped the boolean.
- `Constants` static constructor: removed a duplicated `if (Settings != null)` block that was provably unreachable (the Settings getter never returns null, so the first branch always returned). The default value is already handled by the field initializer and `ExposeData`.